### PR TITLE
Fixed ENVIRONMENT substitution

### DIFF
--- a/start_as_nexus.sh
+++ b/start_as_nexus.sh
@@ -4,4 +4,9 @@ chown nexus:nexus /opt/sonatype-work
 if [ -z "$(ls -A /opt/sonatype-work)" ]; then
   cp -R --preserve=all /opt/sonatype-work-template /opt/sonatype-work
 fi
+
+cd /opt/sonatype-nexus
+mv conf/nexus.properties conf/nexus.properties.old
+awk -v newval="$NEXUS_WEBAPP_CONTEXT_PATH" -v pname="nexus-webapp-context-path" 'BEGIN{ FS="=";OFS="=" } {if($1==pname) $2=newval; print $0;}' conf/nexus.properties.old > conf/nexus.properties
+
 su -c '/opt/start.sh "$@"' - nexus

--- a/start_nexus.sh
+++ b/start_nexus.sh
@@ -1,7 +1,3 @@
 #!/bin/bash
 
-cd /opt/sonatype-nexus
-mv conf/nexus.properties conf/nexus.properties.old
-awk -v newval="$NEXUS_WEBAPP_CONTEXT_PATH" -v pname="nexus-webapp-context-path" 'BEGIN{ FS="=";OFS="=" } {if($1==pname) $2=newval; print $0;}' conf/nexus.properties.old > conf/nexus.properties
-
 exec "/opt/sonatype-nexus/bin/nexus" "console"


### PR DESCRIPTION
Since we switch user from 'root' to nexus we lose all environment variables which means that we don't update the context path as expected.

